### PR TITLE
blackboxprotobuf 修改为github源

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pyaudio
 requests
 pyahocorasick
 lz4
-blackboxprotobuf
+git+https://github.com/ydkhatri/blackboxprotobuf.git
 lxml
 dbutils
 psutil


### PR DESCRIPTION
pypi上的blackboxprotobuf版本有个typo没修复，gihtub上的是修复了的
https://github.com/ydkhatri/blackboxprotobuf/commit/27ae57b552acd424ea539a944a72a2cb23047569